### PR TITLE
Refactoring of Filter functions (#134)

### DIFF
--- a/cmd/examples/example1.go
+++ b/cmd/examples/example1.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
@@ -46,12 +47,24 @@ func main() {
 		CPUArchitecture: &cpuArch,
 	}
 
-	// Pass the Filter struct to the Filter function of your selector instance
-	instanceTypesSlice, err := instanceSelector.Filter(filters)
+	// Pass the Filter struct to the FilteredInstanceTypes function of your
+	// selector instance to get a list of filtered instance types and their details
+	instanceTypesSlice, err := instanceSelector.FilterInstanceTypes(filters)
 	if err != nil {
-		fmt.Printf("Oh no, there was an error :( %v", err)
+		fmt.Printf("Oh no, there was an error getting instance types: %v", err)
 		return
 	}
+
+	// Pass in your list of instance type details to the appropriate output function
+	// in order to format the instance types as printable strings.
+	maxResults := 100
+	instanceTypesSlice, _, err = outputs.TruncateResults(&maxResults, instanceTypesSlice)
+	if err != nil {
+		fmt.Printf("Oh no, there was an error truncating instnace types: %v", err)
+		return
+	}
+	instanceTypes := outputs.SimpleInstanceTypeOutput(instanceTypesSlice)
+
 	// Print the returned instance types slice
-	fmt.Println(instanceTypesSlice)
+	fmt.Println(instanceTypes)
 }

--- a/pkg/selector/outputs/outputs.go
+++ b/pkg/selector/outputs/outputs.go
@@ -26,6 +26,24 @@ import (
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
 )
 
+// TruncateResults is used to prepare a list of details for output by truncating the number of results
+// in the list to have at most maxResults elements. Returns the truncated list of instance types and
+// the number of truncated items.
+func TruncateResults(maxResults *int, instanceTypeInfoSlice []*instancetypes.Details) ([]*instancetypes.Details, int, error) {
+	if maxResults == nil {
+		return instanceTypeInfoSlice, 0, nil
+	} else if *maxResults < 0 {
+		return nil, 0, fmt.Errorf("negative max results value")
+	}
+
+	upperIndex := *maxResults
+	if *maxResults > len(instanceTypeInfoSlice) {
+		upperIndex = len(instanceTypeInfoSlice)
+	}
+
+	return instanceTypeInfoSlice[0:upperIndex], len(instanceTypeInfoSlice) - upperIndex, nil
+}
+
 // SimpleInstanceTypeOutput is an OutputFn which outputs a slice of instance type names
 func SimpleInstanceTypeOutput(instanceTypeInfoSlice []*instancetypes.Details) []string {
 	instanceTypeStrings := []string{}
@@ -35,7 +53,7 @@ func SimpleInstanceTypeOutput(instanceTypeInfoSlice []*instancetypes.Details) []
 	return instanceTypeStrings
 }
 
-// VerboseInstanceTypeOutput is an OutputFn which outputs a slice of instance type names
+// VerboseInstanceTypeOutput is an OutputFn which returns a list of full instance specs
 func VerboseInstanceTypeOutput(instanceTypeInfoSlice []*instancetypes.Details) []string {
 	output, err := json.MarshalIndent(instanceTypeInfoSlice, "", "    ")
 	if err != nil {
@@ -174,7 +192,7 @@ func TableOutputWide(instanceTypeInfoSlice []*instancetypes.Details) []string {
 	return []string{buf.String()}
 }
 
-// OneLineOutput is an output function which prints the instance type names on a single line separated by commas
+// OneLineOutput is an output function which returns the instance type names on a single line separated by commas
 func OneLineOutput(instanceTypeInfoSlice []*instancetypes.Details) []string {
 	instanceTypeNames := []string{}
 	for _, instanceType := range instanceTypeInfoSlice {

--- a/pkg/selector/outputs/outputs_test.go
+++ b/pkg/selector/outputs/outputs_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs"
 	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
@@ -118,4 +119,51 @@ func TestOneLineOutput(t *testing.T) {
 
 	instanceTypeOut = outputs.OneLineOutput(nil)
 	h.Assert(t, len(instanceTypeOut) == 0, "Should return 0 instance types when passed nil")
+}
+
+func TestTruncateResults(t *testing.T) {
+	instanceTypes := getInstanceTypes(t, "25_instances.json")
+
+	// test 0 for max results
+	maxResults := aws.Int(0)
+	truncatedResult, numTrucated, err := outputs.TruncateResults(maxResults, instanceTypes)
+	h.Ok(t, err)
+	h.Assert(t, len(truncatedResult) == 0, fmt.Sprintf("Should return 0 instance types since max results is set to %d, but only %d are returned in total", *maxResults, len(truncatedResult)))
+	h.Assert(t, numTrucated == 25, fmt.Sprintf("Should truncate 25 results, but actually truncated: %d results", numTrucated))
+
+	// test 1 for max results
+	maxResults = aws.Int(1)
+	truncatedResult, numTrucated, err = outputs.TruncateResults(maxResults, instanceTypes)
+	h.Ok(t, err)
+	h.Assert(t, len(truncatedResult) == 1, fmt.Sprintf("Should return 1 instance type since max results is set to %d, but only %d are returned in total", *maxResults, len(truncatedResult)))
+	h.Assert(t, numTrucated == 24, fmt.Sprintf("Should truncate 24 results, but actually truncated: %d results", numTrucated))
+
+	// test 30 for max results
+	maxResults = aws.Int(30)
+	truncatedResult, numTrucated, err = outputs.TruncateResults(maxResults, instanceTypes)
+	h.Ok(t, err)
+	h.Assert(t, len(truncatedResult) == 25, fmt.Sprintf("Should return 25 instance types since max results is set to %d but only %d are returned in total", *maxResults, len(truncatedResult)))
+	h.Assert(t, numTrucated == 0, fmt.Sprintf("Should truncate 0 results, but actually truncated: %d results", numTrucated))
+}
+
+func TestFormatInstanceTypes_NegativeMaxResults(t *testing.T) {
+	instanceTypes := getInstanceTypes(t, "25_instances.json")
+
+	maxResults := aws.Int(-1)
+	formattedResult, numTrucated, err := outputs.TruncateResults(maxResults, instanceTypes)
+
+	h.Assert(t, err != nil, "An error should be returned")
+	h.Assert(t, formattedResult == nil, fmt.Sprintf("returned list should be nil, but it is actually: %s", outputs.OneLineOutput(formattedResult)))
+	h.Assert(t, numTrucated == 0, fmt.Sprintf("No results should be truncated, but %d results were truncated", numTrucated))
+}
+
+func TestFormatInstanceTypes_NilMaxResults(t *testing.T) {
+	instanceTypes := getInstanceTypes(t, "25_instances.json")
+
+	var maxResults *int = nil
+	formattedResult, numTrucated, err := outputs.TruncateResults(maxResults, instanceTypes)
+
+	h.Ok(t, err)
+	h.Assert(t, len(formattedResult) == 25, fmt.Sprintf("Should return 25 instance types since max results is set to nil but only %d are returned in total", len(formattedResult)))
+	h.Assert(t, numTrucated == 0, fmt.Sprintf("No results should be truncated, but actually truncated: %d results", numTrucated))
 }

--- a/pkg/selector/types.go
+++ b/pkg/selector/types.go
@@ -169,9 +169,6 @@ type Filters struct {
 	// Possibly values are: xen or nitro
 	Hypervisor *string
 
-	// MaxResults is the maximum number of instance types to return that match the filter criteria
-	MaxResults *int
-
 	// MemoryRange filter is a range of acceptable DRAM memory in Gibibytes (GiB) for the instance type
 	MemoryRange *ByteQuantityRangeFilter
 


### PR DESCRIPTION
* fixed issue with OD pricing for european regions

* made string replacement more readable in getRegionForPricingAPI

* implemented sorting of instance types

* fixed typo in filtering error message

* moved sort to selector.go and refactored FilterVerbose tests

* brought back FilterWithOutput() in selector.go

* working implementation of refactoring solution

* added method comments

* converted Filter and FilterVerbose tests to TestGetFilteredOutput tests

* added filtering and output tests

* split filter functions into fetching filtered types and outputing types

* removed OutputInstanceTypes. Output functions only in Outputs.go

* fixed typos and updated function comments

* fixed invalid maxResults check in main

* added error to TruncateResults for negative values

* updated error message for formatting instance types

* reduced the amount of times pricing caches are refreshed

* fixed cache refresh related comments

Co-authored-by: Rodrigo Okamoto <rodocp@amazon.com>

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
