### PR TITLE
Revert "Handle pricing api change in aws-sdk-go 1.44.46 (#145)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws/amazon-ec2-instance-selector/v2
 go 1.18
 
 require (
-	github.com/aws/aws-sdk-go v1.44.51
+	github.com/aws/aws-sdk-go v1.44.59
 	github.com/blang/semver/v4 v4.0.0
 	github.com/imdario/mergo v0.3.11
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/aws/aws-sdk-go v1.43.31 h1:yJZIr8nMV1hXjAvvOLUFqZRJcHV7udPQBfhJqawDzI0=
-github.com/aws/aws-sdk-go v1.43.31/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go v1.44.51 h1:jO9hoLynZOrMM4dj0KjeKIK+c6PA+HQbKoHOkAEye2Y=
-github.com/aws/aws-sdk-go v1.44.51/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.59 h1:bkdnNsMvMhFmNLqKDAJ6rKR+S0hjOt/3AIJp2mxOK9o=
+github.com/aws/aws-sdk-go v1.44.59/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/pkg/ec2pricing/ec2pricing_test.go
+++ b/pkg/ec2pricing/ec2pricing_test.go
@@ -75,7 +75,7 @@ func setupMock(t *testing.T, api string, file string) mockedPricing {
 		err = json.Unmarshal(mockFile, &productsMap)
 		h.Assert(t, err == nil, "Error parsing mock json file contents "+mockFilename)
 		productsOutput := pricing.GetProductsOutput{
-			PriceList: []*string{aws.String(string(mockFile))},
+			PriceList: []aws.JSONValue{productsMap},
 		}
 		return mockedPricing{
 			GetProductsPagesResp: productsOutput,

--- a/pkg/ec2pricing/odpricing.go
+++ b/pkg/ec2pricing/odpricing.go
@@ -225,14 +225,10 @@ func (c *OnDemandPricing) getRegionForPricingAPI() string {
 }
 
 // parseOndemandUnitPrice takes a priceList from the pricing API and parses its weirdness
-func (c *OnDemandPricing) parseOndemandUnitPrice(priceDoc *string) (string, float64, error) {
+func (c *OnDemandPricing) parseOndemandUnitPrice(priceList aws.JSONValue) (string, float64, error) {
 	// TODO: this could probably be cleaned up a bit by adding a couple structs with json tags
 	//       We still need to some weird for-loops to get at elements under json keys that are IDs...
 	//       But it would probably be cleaner than this.
-	var priceList map[string]interface{}
-	if err := json.Unmarshal([]byte(*priceDoc), &priceList); err != nil {
-		return "", float64(-1.0), fmt.Errorf("unable to deserialize pricing doc")
-	}
 	attributes, ok := priceList["product"].(map[string]interface{})["attributes"]
 	if !ok {
 		return "", float64(-1.0), fmt.Errorf("unable to find product attributes")


### PR DESCRIPTION
* Revert "Handle pricing api change in aws-sdk-go 1.44.46 (#140)"

This reverts commit cec208c8d60d8348fbba31f791068b65269d459a.

* Update aws-sdk-go to v1.44.59

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
